### PR TITLE
return 0 (instead of nil) when jenkins package is not installed

### DIFF
--- a/lib/facter/jenkins_version.rb
+++ b/lib/facter/jenkins_version.rb
@@ -3,7 +3,7 @@ Facter.add("jenkins_version") do
     begin
       Facter::Util::Resolution.exec("dpkg -p jenkins 2>/dev/null | grep Version | sed 's/Version://'").strip
     rescue
-      nil
+      0
     end
   end
 end


### PR DESCRIPTION
implement fix recommended by @pgr0ss for issue #1
